### PR TITLE
node-http-quickstart to 0.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.2
 - name: node-http-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11


### PR DESCRIPTION
Promote node-http-quickstart to version 0.0.11